### PR TITLE
Update SP SDK to add request/response for scope ‘proofing’

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ ZenKey SDKs (iOS and Android) and web integrations provide effective resources f
 3. Learn the ZenKey flow by exploring the Developer Playground (https://playground.myzenkey.com/playground). You can submit requests to various endpoints and view the responses your users will experience.
 4. Start coding! Visit http://developer.myzenkey.com for documentation (integration guides, references and best practices) and API resources including SDKs for iOS and Android and resources for Web integration.
 
+## Government ID
+
+By default the ZenKey SDK is setup to handle non-premium scopes.  So if you are already an SDK user, and have no plans to support premium scopes, everything still works as is.  No changes needed in your project.
+
+Otherwise, use the ***scopes*** property on **ZenKeyAuthorizeButton** to set a fixed array of supported scopes.  To adopt premium scopes, like government ID, assign an *empty array* of scopes.  In this state, supported scopes will be fetched at launch.
+
 ## Features
 
 - Developer Portal login - Setup your account as a service provider at http://portal.myzenkey.com

--- a/ZenKeySDK.podspec
+++ b/ZenKeySDK.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ZenKeySDK'
-  s.version          = '1.2.0'
+  s.version          = '1.2.1'
   s.summary          = 'ZenKeySDK'
   s.description      = <<-DESC
   The ZenKey SDK enables service providers to authenticate users with their mobile device or web browser.

--- a/ZenKeySDK.xcodeproj/project.pbxproj
+++ b/ZenKeySDK.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		8A6ED9192316DD79007CD4DE /* MockAuthorizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6ED9152316DB7D007CD4DE /* MockAuthorizationService.swift */; };
 		8AB309EA228614AA003E08D8 /* ZenKeySDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 233AF954220A3B080023059C /* ZenKeySDK.framework */; };
 		9F6E913924296BA6003BDD73 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6E913824296BA5003BDD73 /* Theme.swift */; };
+		E61C174B265F699C00D1FCE3 /* MockOpenIdConfigJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C174A265F699C00D1FCE3 /* MockOpenIdConfigJSON.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -183,6 +184,7 @@
 		8A6ED9172316DBBA007CD4DE /* ZenKeySDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZenKeySDK.h; sourceTree = "<group>"; };
 		8AB309E5228614AA003E08D8 /* ZenKeySDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZenKeySDKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F6E913824296BA5003BDD73 /* Theme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		E61C174A265F699C00D1FCE3 /* MockOpenIdConfigJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOpenIdConfigJSON.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -264,6 +266,7 @@
 				8A65F9BE2315EE24002E7826 /* AuthorizationErrorParsing.swift */,
 				8A65F9BF2315EE24002E7826 /* Info.plist */,
 				8A65F9C02315EE24002E7826 /* MobileNetworkSelectionServiceTests.swift */,
+				E61C174A265F699C00D1FCE3 /* MockOpenIdConfigJSON.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -572,6 +575,7 @@
 				8A65FA4F2315EE49002E7826 /* ConfigCacheServiceTests.swift in Sources */,
 				8A65FA532315EE52002E7826 /* MockURLResolver.swift in Sources */,
 				8A65FA572315EE52002E7826 /* MockDiscoveryService.swift in Sources */,
+				E61C174B265F699C00D1FCE3 /* MockOpenIdConfigJSON.swift in Sources */,
 				8A65FA552315EE52002E7826 /* MockNetworkSelectionService.swift in Sources */,
 				8A65FA582315EE52002E7826 /* MockViewControllers.swift in Sources */,
 				8A65FA5A2315EE52002E7826 /* MockOpenIdService.swift in Sources */,

--- a/ZenKeySDK/Sources/Core/DiscoveryService.swift
+++ b/ZenKeySDK/Sources/Core/DiscoveryService.swift
@@ -60,7 +60,7 @@ protocol DiscoveryServiceProtocol {
     /// - Parameters:
     ///   - sim: The sim info to pass to the discovery service
     /// - Returns: Cached instance that conforms to ScopeZen.
-    func cachedScopezen(at sim: SIMProtocol) -> ScopeZen?
+    func cachedScopeZen(at sim: SIMProtocol) -> ScopeZen?
 
     /// Register for updates to qualified sp scopes.
     /// - Parameters:
@@ -69,7 +69,7 @@ protocol DiscoveryServiceProtocol {
 }
 
 extension DiscoveryServiceProtocol {
-    func cachedScopezen(at sim: SIMProtocol) -> ScopeZen? {
+    func cachedScopeZen(at sim: SIMProtocol) -> ScopeZen? {
         .none
     }
 
@@ -114,7 +114,7 @@ class DiscoveryService: DiscoveryServiceProtocol {
         }
     }
 
-    func cachedScopezen(at sim: SIMProtocol) -> ScopeZen? {
+    func cachedScopeZen(at sim: SIMProtocol) -> ScopeZen? {
         guard let simInfo = sim as? SIMInfo else { return .none }
         return configCacheService.config(forSIMInfo: simInfo)
     }
@@ -122,7 +122,7 @@ class DiscoveryService: DiscoveryServiceProtocol {
     func registerScopeSubscriber(sim: SIMInfo?, _ publish: @escaping ScopePublisher) {
         guard let simInfo = sim else { return }
         observer = configCacheService.addCacheObserver() { [weak self] _ in
-            guard let scopezen = self?.cachedScopezen(at: simInfo) else { return }
+            guard let scopezen = self?.cachedScopeZen(at: simInfo) else { return }
             publish(scopezen.serviceProviderSupportedScopes)
         }
     }

--- a/ZenKeySDK/Sources/Core/OpenIdConfig.swift
+++ b/ZenKeySDK/Sources/Core/OpenIdConfig.swift
@@ -20,7 +20,7 @@
 
 import Foundation
 
-struct OpenIdConfig: Equatable {
+struct OpenIdConfig: Equatable, ScopeZen {
     /// The authorization enpdoint to issue authroization requests to.
     let authorizationEndpoint: URL
     /// The open id issuer.
@@ -32,17 +32,27 @@ struct OpenIdConfig: Equatable {
     let linkImage: URL?
     /// TBD: how this is used
     let branding: URL?
+    /// Service Provider's supported scopes
+    var supportedScopes: [String]
 
     init(authorizationEndpoint: URL,
          issuer: URL,
          linkBranding: String? = nil,
          linkImage: URL? = nil,
-         branding: URL? = nil) {
+         branding: URL? = nil,
+         supportedScopes: [String]) {
         self.authorizationEndpoint = authorizationEndpoint
         self.issuer = issuer
         self.linkBranding = linkBranding
         self.linkImage = linkImage
         self.branding = branding
+        self.supportedScopes = supportedScopes
+    }
+
+    // MARK: ScopeZen
+
+    var serviceProviderSupportedScopes: [ScopeProtocol] {
+        Scope.toScopes(rawValues: supportedScopes)
     }
 }
 
@@ -53,6 +63,7 @@ extension OpenIdConfig: Decodable {
         case linkBranding = "link_branding"
         case linkImage = "link_image"
         case branding
+        case supportedScopes = "scopes_supported"
     }
 }
 

--- a/ZenKeySDK/Sources/Core/SDKConfig.swift
+++ b/ZenKeySDK/Sources/Core/SDKConfig.swift
@@ -97,12 +97,45 @@ extension SDKConfig {
     }
 }
 
-protocol ZenKeyBundleProtocol {
+// swiftlint:disable unused_setter_value
+
+public typealias BundleClosure = () -> Void
+public protocol ZenKeyBundleProtocol {
     var clientId: String? { get }
     var urlSchemes: [String] { get }
     var customURLScheme: String? { get }
     var customURLHost: String? { get }
     var customURLPath: String? { get }
+    var info: Any? { get set }
+    var sim: SIMProtocol? { get set }
+    var closure: BundleClosure? { get set }
+}
+
+extension ZenKeyBundleProtocol {
+    public var info: Any? {
+        get {
+            .none
+        }
+        set {
+            return
+        }
+    }
+    public var sim: SIMProtocol? {
+        get {
+            .none
+        }
+        set {
+            return
+        }
+    }
+    public var closure: BundleClosure? {
+        get {
+            .none
+        }
+        set {
+            return
+        }
+    }
 }
 
 private enum PlistKeys: String {
@@ -114,23 +147,23 @@ private enum PlistKeys: String {
 }
 
 extension Bundle: ZenKeyBundleProtocol {
-    var clientId: String? {
+    public var clientId: String? {
         return object(forInfoDictionaryKey: PlistKeys.clientId.rawValue) as? String
     }
 
-    var customURLScheme: String? {
+    public var customURLScheme: String? {
         return object(forInfoDictionaryKey: PlistKeys.customScheme.rawValue) as? String
     }
 
-    var customURLHost: String? {
+    public var customURLHost: String? {
         return object(forInfoDictionaryKey: PlistKeys.customHost.rawValue) as? String
     }
 
-    var customURLPath: String? {
+    public var customURLPath: String? {
         return object(forInfoDictionaryKey: PlistKeys.customPath.rawValue) as? String
     }
 
-    var urlSchemes: [String] {
+    public var urlSchemes: [String] {
         guard
             let urlTypes = object(forInfoDictionaryKey: PlistKeys.bundleURLTypes.rawValue) as? [[String: Any]] else {
                 return []

--- a/ZenKeySDK/Sources/Core/SIMInfo.swift
+++ b/ZenKeySDK/Sources/Core/SIMInfo.swift
@@ -20,7 +20,23 @@
 
 import Foundation
 
-struct SIMInfo: Equatable {
+public protocol SIMProtocol {
+    var mccmnc: String { get }
+    var mcc: String { get }
+    var mnc: String { get }
+}
+
+public extension SIMProtocol {
+    var mcc: String {
+        String(mccmnc.prefix(3))
+    }
+    var mnc: String {
+        String(mccmnc.suffix(3))
+    }
+
+}
+
+struct SIMInfo: Equatable, SIMProtocol {
     let mccmnc: String
 
     init(mcc: String, mnc: String) {

--- a/ZenKeySDK/Sources/Core/Scope.swift
+++ b/ZenKeySDK/Sources/Core/Scope.swift
@@ -20,6 +20,15 @@
 
 import Foundation
 
+/// Defines closure to pass back scopes.
+public typealias ScopePublisher = ([ScopeProtocol]?) -> Void
+
+/// Adopting types know sp's supported scopes.
+public protocol ScopeZen {
+    /// Supported scopes as an array of Scope.
+    var serviceProviderSupportedScopes: [ScopeProtocol] { get }
+}
+
 /// The protocol any type must conform to to represent a scope request.
 public protocol ScopeProtocol {
     /// The string which will represent the scope over the network.
@@ -27,7 +36,7 @@ public protocol ScopeProtocol {
 }
 
 /// The predefined scopes supported by ZenKey.
-public enum Scope: String, ScopeProtocol, Equatable {
+public enum Scope: String, ScopeProtocol, Equatable, CaseIterable {
     /// This scope will return an ID_token from the Token endpoint. Future updates may include
     /// additional data claims in the ID_token.  Note: even the access token is a JWT.
     case openid
@@ -57,8 +66,35 @@ public enum Scope: String, ScopeProtocol, Equatable {
     /// Last four digits of user SSN
     case last4Social = "last_4_social"
 
+    /// GovId
+    case proofing
+
     public var scopeString: String {
         return self.rawValue
+    }
+
+    /// Scopes offered at a premium level of service.
+    public static var premiumScopes: [ScopeProtocol] {
+        [Scope.proofing]
+    }
+
+    /// All sp's should support these scopes.  Computed by Scope.allCases - premiumScopes.
+    public static var universalScopes: [ScopeProtocol] {
+        var allSet = Set(allCases)
+
+        // must convert this to [Scope] as [ScopeProtocol] is not Hashable
+        // Set only works with Hashable
+        let premiumSet = premiumScopes.map { Scope(rawValue: $0.scopeString) }.compactMap { $0 }
+        allSet.subtract(premiumSet)
+        return Array(allSet)
+    }
+
+    /// Convert an array of strings to equivalent array of scopes.
+    /// - Parameters:
+    ///   - rawValues: Array of strings to be returned as scopes.
+    /// - Returns: Array of scopes.
+    public static func toScopes(rawValues: [String]) -> [ScopeProtocol] {
+        rawValues.deduplicateStrings.sorted().map { Scope(rawValue: $0) }.compactMap { $0 }
     }
 }
 

--- a/ZenKeySDK/Sources/Core/ZenKeyAppDelegate.swift
+++ b/ZenKeySDK/Sources/Core/ZenKeyAppDelegate.swift
@@ -147,6 +147,12 @@ public class ZenKeyAppDelegate {
         return currentAuthorizationService.resolve(url: url)
     }
 
+    /// Register for updates to qualified sp scopes.  This is considered the registration
+    /// entry point since ZenKeyAppDelegate is a singleton that is globally visible.
+    /// - Parameters:
+    ///   - sim: The sim info to pass to the discovery service.  Normally the sim is available from
+    ///          the device hardware, so this defaults to .none.  On a simulator you could pass
+    ///          something else.
     func register(sim: SIMProtocol? = .none, _ action: @escaping ScopePublisher) {
         var simInfo: SIMInfo? {
             guard let sim = sim else { return .none }

--- a/ZenKeySDK/Tests/ConfigCacheServiceTests.swift
+++ b/ZenKeySDK/Tests/ConfigCacheServiceTests.swift
@@ -124,7 +124,8 @@ private extension ConfigCacheServiceTests {
         let value = Int.random(in: 0..<100)
         return OpenIdConfig(
             authorizationEndpoint: URL(string: "xci://?bar=\(value)")!,
-            issuer: URL(string: "xci://?bah=\(value)")!
+            issuer: URL(string: "xci://?bah=\(value)")!,
+            supportedScopes: ["openid", "profile", "email", "address"]
         )
     }
 }

--- a/ZenKeySDK/Tests/Constants.swift
+++ b/ZenKeySDK/Tests/Constants.swift
@@ -91,7 +91,8 @@ extension AuthorizationError {
 extension OpenIdConfig {
     static var mocked: OpenIdConfig {
         return OpenIdConfig(authorizationEndpoint: URL.mocked,
-                            issuer: URL.mocked)
+                            issuer: URL.mocked,
+                            supportedScopes: ["openid", "profile", "email", "address"])
     }
 }
 

--- a/ZenKeySDK/Tests/CurrentSIMBrandingProviderTests.swift
+++ b/ZenKeySDK/Tests/CurrentSIMBrandingProviderTests.swift
@@ -40,7 +40,8 @@ class CurrentSIMBrandingProviderTests: XCTestCase {
             issuer: URL.mocked,
             linkBranding: "test mock branding",
             linkImage: URL.mocked,
-            branding: URL.mocked
+            branding: URL.mocked,
+            supportedScopes: ["openid", "profile", "email", "address"]
         )
         configCacheService.cacheConfig(config, forSIMInfo: simInfo)
         XCTAssertEqual(currentSIMBrandingProvider.buttonBranding, config.buttonBranding)
@@ -52,7 +53,8 @@ class CurrentSIMBrandingProviderTests: XCTestCase {
             issuer: URL.mocked,
             linkBranding: "test mock branding",
             linkImage: URL.mocked,
-            branding: URL.mocked
+            branding: URL.mocked,
+            supportedScopes: ["openid", "profile", "email", "address"]
         )
 
         var calls = 0

--- a/ZenKeySDK/Tests/DiscoveryServiceTests.swift
+++ b/ZenKeySDK/Tests/DiscoveryServiceTests.swift
@@ -170,7 +170,8 @@ class DiscoveryServiceTests: XCTestCase {
         mockNetworkService.mockError(.networkError(error))
         let expectedConfig = OpenIdConfig(
             authorizationEndpoint: URL.mocked,
-            issuer: URL.mocked
+            issuer: URL.mocked,
+            supportedScopes: ["openid", "profile", "email", "address"]
         )
         mockConfigCacheService.cacheConfig(
             expectedConfig,
@@ -217,7 +218,8 @@ class DiscoveryServiceTests: XCTestCase {
                 simInfo: MockSIMs.tmobile,
                 openIdConfig: OpenIdConfig(
                     authorizationEndpoint: URL(string: "https://xcid.t-mobile.com/verify/authorize")!,
-                    issuer: URL(string: "https://brass.account.t-mobile.com")!
+                    issuer: URL(string: "https://brass.account.t-mobile.com")!,
+                    supportedScopes: ["openid", "profile", "email", "address"]
                 )
             )
 
@@ -251,7 +253,8 @@ class DiscoveryServiceTests: XCTestCase {
                 simInfo: MockSIMs.tmobile,
                 openIdConfig: OpenIdConfig(
                     authorizationEndpoint: URL(string: "https://xcid.t-mobile.com/verify/authorize")!,
-                    issuer: URL(string: "https://brass.account.t-mobile.com")!
+                    issuer: URL(string: "https://brass.account.t-mobile.com")!,
+                    supportedScopes: ["openid", "profile", "email", "address"]
                 )
             )
 
@@ -289,7 +292,8 @@ class DiscoveryServiceTests: XCTestCase {
 
                 let expectedResult = OpenIdConfig(
                     authorizationEndpoint: URL(string: "https://xcid.t-mobile.com/verify/authorize")!,
-                    issuer: URL(string: "https://brass.account.t-mobile.com")!
+                    issuer: URL(string: "https://brass.account.t-mobile.com")!,
+                    supportedScopes: ["openid", "profile", "email", "address"]
                 )
 
                 XCTAssertEqual(

--- a/ZenKeySDK/Tests/MockOpenIdConfigJSON.swift
+++ b/ZenKeySDK/Tests/MockOpenIdConfigJSON.swift
@@ -1,0 +1,97 @@
+//
+//  MockOpenIdConfigJSON.swift
+//  ZenKeySDK
+//
+//  Created by Anthony Arthur on 5/27/21.
+//  Copyright © 2021 ZenKey, LLC.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+let mockOpenIDConfigNoProofing = """
+{
+\"issuer\":\"issuer\", \
+\"authorization_endpoint\":\"authorization_endpoint\", \
+\"token_endpoint\":\"token_endpoint\", \
+\"userinfo_endpoint\":\"userinfo_endpoint\", \
+\"jwks_uri\":\"jwks_uri\", \
+\"server_initiated_endpoint\":\"server_initiated_endpoint\", \
+\"server_initiated_authorization_endpoint\":\"server_initiated_authorization_endpoint\", \
+\"server_initiated_cancel_endpoint\":\"server_initiated_cancel_endpoint\", \
+\"revocation_endpoint\":\"revocation_endpoint\", \
+\"response_types_supported\":[\"async_token\", \"code\"], \
+\"subject_types_supported\":[\"pairwise\"], \
+\"id_token_signing_alg_values_supported\":[\"RS256\"], \
+\"scopes_supported\":[\"name\",\"email\",\"address\",\"phone\",\"openid\",\"postal_code\",\"birthdate\",\"events\"], \
+\"mccmnc\":310260, \
+\"token_endpoint_auth_methods_supported\":[\"client_secret_basic\",\"client_assertion_jwt\"], \
+\"claims_supported\":[\"sub\",\"name\",\"given_name\",\"family_name\",\"email\",\"email_verified\",\"phone_number\",\"address\"], \
+\"branding\":\"branding\", \
+\"link_branding\":\"link_branding", \
+\"link_img\":\"link_img\", \
+\"ui_locales_supported\":[\"en-US\"], \
+\"registration_endpoint\":\"registration_endpoint\", \
+\"grant_types_supported\":[\"authorization_code\"], \
+\"acr_values_supported\":[\"a1\",\"a3\"], \
+\"service_documentation\":\"service_documentation\", \
+\"claims_parameter_supported\":false, \
+\"request_parameter_supported\":true, \
+\"request_uri_parameter_supported\":false, \
+\"op_policy_uri\":\"op_policy_uri\", \
+\"usertrait_endpoint\":\"usertrait_endpoint\", \
+\"usertraits_supported\":\"usertraits_supported\", \
+\"events_supported\":[\"consent_revoked\"], \
+\"events_endpoint\":\"events_endpoint\", \
+\"user_porting_endpoint\":\"user_porting_endpoint\", \
+}
+"""
+
+let mockOpenIDConfigWithProofing = """
+{
+\"issuer\":\"issuer\", \
+\"authorization_endpoint\":\"authorization_endpoint\", \
+\"token_endpoint\":\"token_endpoint\", \
+\"userinfo_endpoint\":\"userinfo_endpoint\", \
+\"jwks_uri\":\"jwks_uri\", \
+\"server_initiated_endpoint\":\"server_initiated_endpoint\", \
+\"server_initiated_authorization_endpoint\":\"server_initiated_authorization_endpoint\", \
+\"server_initiated_cancel_endpoint\":\"server_initiated_cancel_endpoint\", \
+\"revocation_endpoint\":\"revocation_endpoint\", \
+\"response_types_supported\":[\"async_token\", \"code\"], \
+\"subject_types_supported\":[\"pairwise\"], \
+\"id_token_signing_alg_values_supported\":[\"RS256\"], \
+\"scopes_supported\":[\"name\",\"email\",\"address\",\"phone\",\"openid\",\"postal_code\",\"birthdate\",\"events\",\"proofing\"], \
+\"mccmnc\":310260, \
+\"token_endpoint_auth_methods_supported\":[\"client_secret_basic\",\"client_assertion_jwt\"], \
+\"claims_supported\":[\"sub\",\"name\",\"given_name\",\"family_name\",\"email\",\"email_verified\",\"phone_number\",\"address\"], \
+\"branding\":\"branding\", \
+\"link_branding\":\"link_branding", \
+\"link_img\":\"link_img\", \
+\"ui_locales_supported\":[\"en-US\"], \
+\"registration_endpoint\":\"registration_endpoint\", \
+\"grant_types_supported\":[\"authorization_code\"], \
+\"acr_values_supported\":[\"a1\",\"a3\"], \
+\"service_documentation\":\"service_documentation\", \
+\"claims_parameter_supported\":false, \
+\"request_parameter_supported\":true, \
+\"request_uri_parameter_supported\":false, \
+\"op_policy_uri\":\"op_policy_uri\", \
+\"usertrait_endpoint\":\"usertrait_endpoint\", \
+\"usertraits_supported\":\"usertraits_supported\", \
+\"events_supported\":[\"consent_revoked\"], \
+\"events_endpoint\":\"events_endpoint\", \
+\"user_porting_endpoint\":\"user_porting_endpoint\", \
+}
+"""

--- a/ZenKeySDK/Tests/Mocks/MockDiscoveryService.swift
+++ b/ZenKeySDK/Tests/Mocks/MockDiscoveryService.swift
@@ -27,7 +27,8 @@ class MockDiscoveryService: DiscoveryServiceProtocol {
         simInfo: MockSIMs.tmobile,
         openIdConfig: OpenIdConfig(
             authorizationEndpoint: URL.mocked,
-            issuer: URL.mocked
+            issuer: URL.mocked,
+            supportedScopes: ["openid", "profile", "email", "address"]
         )
     )
 

--- a/ZenKeySDK/Tests/OpenIdServiceTests.swift
+++ b/ZenKeySDK/Tests/OpenIdServiceTests.swift
@@ -255,7 +255,8 @@ extension OpenIdServiceTests {
         simInfo: MockSIMs.tmobile,
         openIdConfig: OpenIdConfig(
             authorizationEndpoint: URL.mocked,
-            issuer: URL.mocked
+            issuer: URL.mocked,
+            supportedScopes: ["openid", "profile", "email", "address"]
         )
     )
 }

--- a/ZenKeySDK/Tests/ScopeTests.swift
+++ b/ZenKeySDK/Tests/ScopeTests.swift
@@ -21,6 +21,8 @@
 import XCTest
 @testable import ZenKeySDK
 
+// swiftlint:disable empty_enum_arguments
+
 class ScopeTests: XCTestCase {
     var dupeScopes: [ScopeProtocol] = {
         let scopes: [Scope] = [.name, .openid, .phone, .phone, .name, .name, .openid]
@@ -35,4 +37,112 @@ class ScopeTests: XCTestCase {
         let formattedString = OpenIdScopes(requestedScopes: dupeScopes).networkFormattedString
         XCTAssertEqual(formattedString, "name openid phone")
     }
+
+    func mockOpenIdConfig(json: String) -> OpenIdConfig? {
+        let mockRequest = URLRequest(url: URL.mocked)
+        let jsonDecoder = JSONDecoder()
+        let mockPayload = json.data(using: .utf8)
+        let result: Result<OpenIdConfig, NetworkServiceError> = NetworkService.JSONResponseParser.parseDecodable(
+            with: jsonDecoder,
+            fromData: mockPayload,
+            request: mockRequest,
+            error: .none
+        )
+        switch result {
+        case .success(let config):
+            return config
+        case .failure( _ ):
+            return .none
+        }
+    }
+
+    func testUniversalScopesNotEmpty() {
+        XCTAssertFalse(Scope.universalScopes.isEmpty)
+    }
+
+    func testUniversalScopesNotInPremium() {
+        let subSet = Scope.universalScopes.filter { item in
+            Scope.premiumScopes.contains { premiumItem in
+            item.scopeString == premiumItem.scopeString } }
+        XCTAssertTrue(subSet.isEmpty)
+    }
+
+    func testStringToScope() {
+        let input = ["name", "openid", "phone", "proofing"]
+        XCTAssertEqual(Scope.toScopes(rawValues: input).toOpenIdScopes, input.joined(separator: " "))
+    }
+
+    func testStringToScopeNoDupsSorted() {
+        let input = ["openid", "name", "phone", "phone", "name", "name", "openid"]
+        XCTAssertEqual(Scope.toScopes(rawValues: input).toOpenIdScopes, "name openid phone")
+    }
+
+    func testStringToScopeNonExist() {
+        let realScopeName = "proofing"
+        let input = ["\(realScopeName)", "elmer", "fudd", "yosemite", "sam"]
+        XCTAssertEqual(Scope.toScopes(rawValues: input).toOpenIdScopes, "\(realScopeName)")
+    }
+
+    func testOpenIdConfigWithProofingScope() {
+        guard let openIdConfigWithProofing = mockOpenIdConfig(json: mockOpenIDConfigWithProofing) else {
+            XCTFail("Invalid JSON")
+            return
+        }
+        XCTAssertTrue(openIdConfigWithProofing.serviceProviderSupportedScopes.map { $0.scopeString }.contains(Scope.proofing.rawValue))
+    }
+
+    func testOpenIdConfigWithOutProofingScope() {
+        guard let openIdConfigNoProofing = mockOpenIdConfig(json: mockOpenIDConfigNoProofing) else {
+            XCTFail("Invalid JSON")
+            return
+        }
+        XCTAssertFalse(openIdConfigNoProofing.serviceProviderSupportedScopes.map { $0.scopeString }.contains(Scope.proofing.rawValue))
+    }
+
+    // Tests that my subscriber is notified when the openIdConfig gets cached in ConfigCacheService
+    func testPublisherToSubscriber() {
+        let timeout = 5.0
+        let expect = XCTestExpectation(description: "wait")
+        let sim = MockSIMInfo()
+        var mockBundle = MockInjectionBundle()
+        mockBundle.info = mockOpenIdConfig(json: mockOpenIDConfigWithProofing)
+        mockBundle.sim = sim
+        mockBundle.closure = {
+            // SDK bootstrap complete, stand up subscriber for publisher
+            _ = MockSubscriber(expect: expect, sim: sim)
+        }
+        ZenKeyAppDelegate.shared.inject(bundle: mockBundle)
+        ZenKeyAppDelegate.shared.application(UIApplication.shared,
+                                             didFinishLaunchingWithOptions: .none)
+        wait(for: [expect], timeout: timeout)
+    }
+}
+
+struct MockSubscriber {
+    var expect: XCTestExpectation
+    var sim: SIMProtocol
+    init(expect: XCTestExpectation, sim: SIMProtocol) {
+        self.expect = expect
+        self.sim = sim
+
+        // register to be notified when openIdConfig gets cached in ConfigCacheService
+        ZenKeyAppDelegate.shared.register(sim: sim) { _ in
+            expect.fulfill()
+        }
+    }
+}
+
+struct MockInjectionBundle: ZenKeyBundleProtocol {
+    var clientId: String? = "ccid-pxap3evoqfczqmjk"
+    var urlSchemes: [String] = ["ccid-pxap3evoqfczqmjk"]
+    var customURLScheme: String? = "ccid-pxap3evoqfczqmjk"
+    var customURLHost: String? = "com.xci.provider.sdk"
+    var customURLPath: String? = ""
+    var info: Any?
+    var sim: SIMProtocol?
+    var closure: BundleClosure?
+}
+
+struct MockSIMInfo: SIMProtocol {
+    var mccmnc: String = "310260"
 }


### PR DESCRIPTION
### Addresses
This Pull Request addresses [ZKGVID-127](https://crosscarrier.atlassian.net/browse/ZKGVID-127).

### Notes:
The challenge was engineering a solution whose impact on the customer was minimal.  Ideally my goal is for non-GovID customers, the upgrade is transparent.  Otherwise for those interested in GovId, only minor changes are needed.  See comments at line 55 in ZenKeyAuthorizeButton for how.

### Testing Instructions:
Use the BankApp from [ZM-1214 PR](https://github.com/MyZenKey/XCI-BankApp-iOS/pull/6) to test.  Easiest to edit Podfile then run pod install.

`pod 'ZenKeySDK', :path => '~/<path_to_sp-sdk-ios'>`

#### See screen shots below.  
For Config A, set a BP at line 245 in ZenKeyAuthorizeButton.swift.
For Config B, set a BP at line 243 in ZenKeyAuthorizeButton.swift.

You should hit this when the app loads.  See debug configurations in the screen shots below.  Changing any of these settings will immediately force quit the app.  Restart and check that your settings are correct.  To open the debug menu option-click on simulator, two finger tap on device -- keep tapping until it opens.

### Screen Shots
Config A
![Screen Shot 2021-05-28 at 6 04 51 PM](https://user-images.githubusercontent.com/81264906/120046693-b8445e80-bfe0-11eb-8be3-8fcdd02df82b.png)
Config B
![Screen Shot 2021-05-28 at 6 02 54 PM](https://user-images.githubusercontent.com/81264906/120046723-d01be280-bfe0-11eb-8ed6-b8f367ae00d1.png)

