### PR TITLE
Update SP SDK to add request/response for scope ‘proofing’

### DIFF
--- a/ZenKeySDK.podspec
+++ b/ZenKeySDK.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ZenKeySDK'
-  s.version          = '1.2.0'
+  s.version          = '1.2.1'
   s.summary          = 'ZenKeySDK'
   s.description      = <<-DESC
   The ZenKey SDK enables service providers to authenticate users with their mobile device or web browser.

--- a/ZenKeySDK/Sources/Core/Scope.swift
+++ b/ZenKeySDK/Sources/Core/Scope.swift
@@ -27,7 +27,7 @@ public protocol ScopeProtocol {
 }
 
 /// The predefined scopes supported by ZenKey.
-public enum Scope: String, ScopeProtocol, Equatable {
+public enum Scope: String, ScopeProtocol, Equatable, CaseIterable {
     /// This scope will return an ID_token from the Token endpoint. Future updates may include
     /// additional data claims in the ID_token.  Note: even the access token is a JWT.
     case openid
@@ -57,8 +57,31 @@ public enum Scope: String, ScopeProtocol, Equatable {
     /// Last four digits of user SSN
     case last4Social = "last_4_social"
 
+    /// GovId
+    case proofing
+
     public var scopeString: String {
         return self.rawValue
+    }
+
+    /// Scopes offered at a premium level of service.
+    public static var premiumScopes: [Scope] {
+        [Scope.proofing]
+    }
+
+    /// All sp's should support these scopes.  Computed by Scope.allCases - premiumScopes.
+    public static var universalScopes: [Scope] {
+        var allSet = Set(allCases)
+        allSet.subtract(premiumScopes)
+        return Array(allSet)
+    }
+
+    /// Convert an array of strings to equivalent array of scopes.
+    /// - Parameters:
+    ///   - rawValues: Array of strings to be returned as scopes.
+    /// - Returns: Array of scopes.
+    public static func toScopes(rawValues: [String]) -> [ScopeProtocol] {
+        rawValues.deduplicateStrings.sorted().map { Scope(rawValue: $0) }.compactMap { $0 }
     }
 }
 

--- a/ZenKeySDK/Tests/ScopeTests.swift
+++ b/ZenKeySDK/Tests/ScopeTests.swift
@@ -35,4 +35,32 @@ class ScopeTests: XCTestCase {
         let formattedString = OpenIdScopes(requestedScopes: dupeScopes).networkFormattedString
         XCTAssertEqual(formattedString, "name openid phone")
     }
+
+    func testPremiumScopesExclusive() {
+        XCTAssertTrue(Scope.premiumScopes.filter { Scope.universalScopes.contains($0) }.isEmpty)
+    }
+
+    func testUniversalScopesExclusive() {
+        XCTAssertTrue(Scope.universalScopes.filter { Scope.premiumScopes.contains($0) }.isEmpty)
+    }
+
+    func testUniversalScopesNotEmpty() {
+        XCTAssertFalse(Scope.universalScopes.isEmpty)
+    }
+
+    func testStringToScope() {
+        let input = ["name", "openid", "phone", "proofing"]
+        XCTAssertEqual(Scope.toScopes(rawValues: input).toOpenIdScopes, input.joined(separator: " "))
+    }
+
+    func testStringToScopeNoDupsSorted() {
+        let input = ["openid", "name", "phone", "phone", "name", "name", "openid"]
+        XCTAssertEqual(Scope.toScopes(rawValues: input).toOpenIdScopes, "name openid phone")
+    }
+
+    func testStringToScopeNonExist() {
+        let realScopeName = "proofing"
+        let input = ["\(realScopeName)", "elmer", "fudd", "yosemite", "sam"]
+        XCTAssertEqual(Scope.toScopes(rawValues: input).toOpenIdScopes, "\(realScopeName)")
+    }
 }


### PR DESCRIPTION
### Addresses
This Pull Request addresses [ZKGVID-127](https://crosscarrier.atlassian.net/browse/ZKGVID-127).  If you saw this [before](https://github.com/MyZenKey/sp-sdk-ios/pull/9), that's because I discovered a new detail and closed it.  Now there are far fewer changes.

### Debug Menu Settings:
To open the debug menu option-click on simulator, two finger tap on device -- keep tapping until it opens.  Changing any of these settings will immediately force quit the app. Restart and check that your settings are correct.

### Testing Instructions:
Use the BankApp from [ZKGVID-126 PR](https://github.com/MyZenKey/XCI-BankApp-iOS/pull/8) to test.  Easiest to edit Podfile then run pod install.  Set a BP at line 34 in LoginViewController and run.

`pod 'ZenKeySDK', :path => '~/<path_to_sp-sdk-ios'>`

#### See screen shots below. 

- Config A - fixed scopes from SP as assigned at line 34 in LoginViewController by ClientSideService.
- Config B - scopes managed by debug menu.  Either includes proofing or not.

`(lldb) p button.scopes`

### Screen Shots
Config A
![Screen Shot 2021-05-28 at 6 04 51 PM](https://user-images.githubusercontent.com/81264906/120046693-b8445e80-bfe0-11eb-8be3-8fcdd02df82b.png)
Config B
![Screen Shot 2021-05-28 at 6 02 54 PM](https://user-images.githubusercontent.com/81264906/120046723-d01be280-bfe0-11eb-8ed6-b8f367ae00d1.png)
